### PR TITLE
See description for why case would've been just fine.

### DIFF
--- a/fizzbuzz.rb
+++ b/fizzbuzz.rb
@@ -1,7 +1,7 @@
 # 0_0dea was here.
 1.upto 100 do |m|
  puts "Fizz#{""}if m % 5 ==0
- puts "Bu
+ puts "Buz
 =en 0
   "FizzBu"
  else


### PR DESCRIPTION
Here's one way to use `case` to write a pretty clean FizzBuzz:

``` ruby
puts (1..100).map { |n|
  case
  when n % 3 < 1 ; "Fizz#{'Buzz' if n % 5 < 1}"
  when n % 5 < 1 ; "Buzz"
  else n
  end
}
```

Another:

``` ruby
puts (1..100).map { |n|
  case [n % 3 < 1, n % 5 < 1]
  when [true, false] ; "Fizz"
  when [false, true] ; "Buzz"
  when [true,  true] ; "FizzBuzz"
  else n
  end
}
```

This last one doesn't use `case`, but it's still my favorite:

``` ruby
_=$$/$$;__=_-_;@_=_+_;$_=@_+_;$__=@_+$_;$-_=$__*$_
@__ =''<<$-_*($__+$_)+@_
$___=''<<$-_*$__-$__<<$-_*($__+@_)<<@__<<@__
@___=''<<$-_*$__-$_*$_<<$-_*($__+$_)-$_<<@__<<@__
(___=->{$.+=_;$><<($.%$-_==__ ?$___+@___:$.%$_==__ ?$___:$.%
$__==__ ?@___:$.)<<(''<<$__*@_);$.<($__*@_)**@_?___[]:_})[]
```
